### PR TITLE
Publish package as public

### DIFF
--- a/.github/workflows/node-publish.yaml
+++ b/.github/workflows/node-publish.yaml
@@ -13,6 +13,6 @@ jobs:
           node-version: '16.x'
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
-      - run: npm publish
+      - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Publish package as public to fix error from [previous attempt](https://github.com/allenporter/recurrence-rule-editor/actions/runs/3545018664).