### PR TITLE
Add support for configured firstDay of week

### DIFF
--- a/src/recurrence-rule-editor/RecurrenceRuleEditor.ts
+++ b/src/recurrence-rule-editor/RecurrenceRuleEditor.ts
@@ -9,11 +9,12 @@ import '@material/mwc-textfield/mwc-textfield.js';
 import './button-toggle/button-toggle.js';
 import { RRule, Weekday, ByWeekday } from 'rrule';
 import type { Options, WeekdayStr } from 'rrule';
+import type { LocaleData } from './locale-data.js';
 import {
   RepeatFrequency,
   RepeatEnd,
   convertFrequency,
-  WEEKDAYS,
+  getWeekdays,
   WEEKDAY_NAME,
   intervalSuffix,
   DEFAULT_COUNT,
@@ -35,6 +36,8 @@ export class RecurrenceRuleEditor extends LitElement {
 
   @property() public value: string = '';
 
+  @property() public localeData: LocaleData = {};
+
   @state() private _computedRRule = '';
 
   @state() private _freq?: RepeatFrequency = 'none';
@@ -49,14 +52,12 @@ export class RecurrenceRuleEditor extends LitElement {
 
   @state() private _until?: Date;
 
-  private _allWeekdays: WeekdayStr[] = WEEKDAYS.map(
-    (day: Weekday) => day.toString() as WeekdayStr
-  );
+  private _allWeekdays?: WeekdayStr[];
 
   protected willUpdate(changedProps: PropertyValues) {
     super.willUpdate(changedProps);
 
-    if (!changedProps.has('value')) {
+    if (!changedProps.has('value') && !changedProps.has('localeData')) {
       return;
     }
     this._interval = 1;
@@ -64,6 +65,10 @@ export class RecurrenceRuleEditor extends LitElement {
     this._end = 'never';
     this._count = undefined;
     this._until = undefined;
+
+    this._allWeekdays = getWeekdays(this.localeData.firstDay).map(
+      (day: Weekday) => day.toString() as WeekdayStr
+    );
 
     this._computedRRule = this.value;
     if (this.value === '') {
@@ -147,7 +152,7 @@ export class RecurrenceRuleEditor extends LitElement {
     return html`
       ${this.renderInterval()}
       <div>
-        ${this._allWeekdays.map(
+        ${this._allWeekdays!.map(
           item => html`
             <button-toggle
               label="${WEEKDAY_NAME[item]}"

--- a/src/recurrence-rule-editor/index.ts
+++ b/src/recurrence-rule-editor/index.ts
@@ -1,1 +1,2 @@
 export { RecurrenceRuleEditor } from './RecurrenceRuleEditor.js';
+export { LocaleData } from './locale-data.js';

--- a/src/recurrence-rule-editor/locale-data.ts
+++ b/src/recurrence-rule-editor/locale-data.ts
@@ -1,0 +1,10 @@
+export interface LocaleData {
+  firstDay?: number;
+
+  /*
+    In the future consider other locale data:
+    daysOfWeek: string[];
+    monthNames: string[];
+    msg: (key: string) => string;
+    */
+}

--- a/src/recurrence-rule-editor/recurrence.ts
+++ b/src/recurrence-rule-editor/recurrence.ts
@@ -100,6 +100,19 @@ export const WEEKDAYS = [
   RRule.SA,
 ];
 
+export function getWeekdays(firstDay?: number) {
+  if (firstDay === undefined || firstDay === 0) {
+    return WEEKDAYS;
+  }
+  let iterator = firstDay;
+  const weekDays: Weekday[] = [...WEEKDAYS];
+  while (iterator > 0) {
+    weekDays.push(weekDays.shift() as Weekday);
+    iterator -= 1;
+  }
+  return weekDays;
+}
+
 export function ruleByWeekDay(
   weekdays: Set<WeekdayStr>
 ): Weekday[] | undefined {

--- a/test/recurrence-rule-editor.test.ts
+++ b/test/recurrence-rule-editor.test.ts
@@ -181,6 +181,38 @@ describe('RecurrenceRuleEditor', () => {
     }
   });
 
+  it('can change first day of the day of week', async () => {
+    const el = await fixture<RecurrenceRuleEditor>(
+      html`<recurrence-rule-editor
+        .localeData=${{ firstDay: 1 }}
+      ></recurrence-rule-editor>`
+    );
+    await elementUpdated(el);
+
+    const sel = el.shadowRoot!.querySelector('mwc-select')!;
+    setTimeout(async () => {
+      sel.select(3); // Weekly
+    });
+
+    {
+      const { detail } = await oneEvent(el, 'value-changed');
+      expect(detail.value).to.equal('FREQ=WEEKLY');
+    }
+
+    // eslint-disable-next-line no-undef
+    const toggles: NodeListOf<ButtonToggle> =
+      el.shadowRoot!.querySelectorAll('button-toggle');
+    expect(toggles.length).to.equal(7);
+
+    setTimeout(async () => {
+      toggles[0].shadowRoot!.querySelector('mwc-button')!.click();
+    });
+    {
+      const { detail } = await oneEvent(el, 'value-changed');
+      expect(detail.value).to.equal('FREQ=WEEKLY;BYDAY=MO'); // First day is Monday instead of Sunday
+    }
+  });
+
   it('can multi-select day of week', async () => {
     const el = await fixture<RecurrenceRuleEditor>(
       html`<recurrence-rule-editor></recurrence-rule-editor>`


### PR DESCRIPTION
Add support for configured firstDay of week. This follows the pattern of the existing vue date picker component.

0 means Sunday, 1 = Monday, etc. There may be a better way to do this based on locale when nothing is specified.

Issue #16