### PR TITLE
Add start input w/ monthly recurrence variations and weekday adjustment

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -40,6 +40,17 @@
   <script type="module">
     import { html, render } from 'lit';
     import '../dist/src/recurrence-rule-editor/recurrence-rule-editor.js';
+    import { parse } from 'date-fns';
+
+
+    function _dtstartChanged(e) {
+      // Drop local timezone conversion by getting date in UTC
+      const inputDate = e.detail.value.toISOString().split('T')[0];
+      const newDate = parse(inputDate, 'yyyy-MM-dd', new Date())
+      console.log(`Date input chagned: ${newDate.toISOString()}`);
+      const ruleElement = document.querySelector('recurrence-rule-editor');
+      ruleElement.dtstart = newDate;
+    }
 
     function _valueChanged(e) {
       const ruleElement = document.querySelector('#rule');
@@ -48,7 +59,7 @@
 
     render(
       html`
-        <recurrence-rule-editor @value-changed=${_valueChanged}>
+        <recurrence-rule-editor start=true .dtstart=${new Date(2022, 9, 31)} @value-changed=${_valueChanged} @dtstart-changed=${_dtstartChanged}>
         </recurrence-rule-editor>
       `,
       document.querySelector('#demo')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@allenporter/recurrence-rule-editor",
-  "version": "0.0.1",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@allenporter/recurrence-rule-editor",
-      "version": "0.0.1",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@custom-elements-manifest/analyzer": "^0.6.6",

--- a/src/recurrence-rule-editor/locale-data.ts
+++ b/src/recurrence-rule-editor/locale-data.ts
@@ -1,5 +1,5 @@
 export interface LocaleData {
-  firstDay?: number;
+  firstDay?: 0 | 1 | 2 | 3 | 4 | 5 | 6 | undefined;
 
   /*
     In the future consider other locale data:

--- a/test/recurrence-rule-editor.test.ts
+++ b/test/recurrence-rule-editor.test.ts
@@ -470,6 +470,21 @@ describe('RecurrenceRuleEditor', () => {
     expect(sel.selected!.value).to.equal('monthly');
   });
 
+  /*
+XXX
+  it('can parse a monthly "rrule" as input', async () => {
+    const el = await fixture<RecurrenceRuleEditor>(
+      html`<recurrence-rule-editor dtstart=${new Date(2022, 10, 25)}
+        value="FREQ=MONTHLY;BYDAY=-TU"
+      ></recurrence-rule-editor>`
+    );
+    const sel = el.shadowRoot!.querySelector('mwc-select')!;
+    await elementUpdated(sel);
+    expect(sel.selected).not.equal(null);
+    expect(sel.selected!.value).to.equal('monthly');
+  });
+  */
+
   it('can parse a weekly "rrule" as input', async () => {
     const el = await fixture<RecurrenceRuleEditor>(
       html`<recurrence-rule-editor

--- a/test/recurrence.test.ts
+++ b/test/recurrence.test.ts
@@ -1,0 +1,39 @@
+import { expect } from '@open-wc/testing';
+import { getWeekydaysForMonth } from '../src/recurrence-rule-editor/recurrence.js';
+
+describe('recurrence', () => {
+  it('can return last tuesday 2022-10-25', async () => {
+    const result = getWeekydaysForMonth(new Date(2022, 9, 25));
+    expect(result.map(x => x.toString())).to.deep.equal(['+4TU', '-1TU']);
+  });
+
+  it('can return fourth monday 2022-10-24', async () => {
+    const result = getWeekydaysForMonth(new Date(2022, 9, 24));
+    expect(result.map(x => x.toString())).to.deep.equal(['+4MO']);
+  });
+
+  it('can return last monday 2022-10-31', async () => {
+    const result = getWeekydaysForMonth(new Date(2022, 9, 31));
+    expect(result.map(x => x.toString())).to.deep.equal(['-1MO']);
+  });
+
+  it('can return first Tuesday 2022-11-1', async () => {
+    const result = getWeekydaysForMonth(new Date(2022, 10, 1));
+    expect(result.map(x => x.toString())).to.deep.equal(['+1TU']);
+  });
+
+  it('can return last Wednesday 2022-11-30', async () => {
+    const result = getWeekydaysForMonth(new Date(2022, 10, 30));
+    expect(result.map(x => x.toString())).to.deep.equal(['-1WE']);
+  });
+
+  it('can return second Wednesday 2022-12-14', async () => {
+    const result = getWeekydaysForMonth(new Date(2022, 11, 14));
+    expect(result.map(x => x.toString())).to.deep.equal(['+2WE']);
+  });
+
+  it('can return third Sunday', async () => {
+    const result = getWeekydaysForMonth(new Date(2022, 11, 18));
+    expect(result.map(x => x.toString())).to.deep.equal(['+3SU']);
+  });
+});


### PR DESCRIPTION
Add an optional dtstart section of the component, as well as input. This is needed to manage two aspects of recurrence:
- Monthly variations such as "On the first Sunday", "On the last Wednesday" (in addition to "On the 2nd day of the month")
- Weekly auto selecting of days of the week (e.g. select Tuesday if the start date is a tuesday)